### PR TITLE
Write responses per question

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Set any necessary environment variables (for example `LM_STUDIO_URL` and `LM_STU
 python benchmark_outline.py
 ```
 
+This will write model responses to a `report/` directory, creating one `Q###.txt`
+file for each question. Use the `--output-dir` argument to change where the
+files are stored.
+
 The script loads all questions, queries the model, and prints placeholder scores. Implement `LMStudioClient.generate` and `grade` to perform real evaluations.
 
 ## Tests

--- a/benchmark_outline.py
+++ b/benchmark_outline.py
@@ -90,19 +90,21 @@ def run_benchmark(client: LMStudioClient, questions: List[str]) -> List[str]:
 def grade(
     responses: List[str],
     answers: List[str],
-    output_file: Optional[str] = None,
+    output_dir: Optional[str] = None,
 ) -> Dict[int, float]:
     """Placeholder grading logic.
 
-    All responses are written to ``output_file`` if provided so that they can be
-    graded by an external model. Each line of the file contains ``Q###:``
-    followed by the model's response for that question.
+    All responses are saved under ``output_dir`` if provided so that they can be
+    graded by an external model. Each question gets its own ``Q###.txt`` file
+    containing the model's response.
     """
 
-    if output_file:
-        with open(output_file, "w", encoding="utf-8") as f:
-            for i, resp in enumerate(responses, start=1):
-                f.write(f"Q{i:03}: {resp}\n")
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        for i, resp in enumerate(responses, start=1):
+            file_path = os.path.join(output_dir, f"Q{i:03}.txt")
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(resp)
 
     scores: Dict[int, float] = {}
     for i, _ in enumerate(responses, start=1):
@@ -127,8 +129,8 @@ def main():
         help='Path to the directory containing answer .md files'
     )
     parser.add_argument(
-        '--output', type=str, default='responses.txt',
-        help='File to write model responses for external grading'
+        '--output-dir', type=str, default='report',
+        help='Directory to write model responses for external grading'
     )
     args = parser.parse_args()
 
@@ -139,7 +141,7 @@ def main():
     print(f"Loaded {len(questions)} questions and {len(answers)} answers.")
     print("Running benchmark...")
     responses = run_benchmark(client, questions)
-    scores = grade(responses, answers, args.output)
+    scores = grade(responses, answers, args.output_dir)
 
     print("Results:")
     for idx, score in scores.items():

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -42,10 +42,8 @@ def test_run_and_grade(tmp_path):
     assert responses == ["response 1", "response 2"]
     assert client.prompts == questions
 
-    output_file = tmp_path / "responses.txt"
-    scores = grade(responses, ["a", "b"], str(output_file))
+    output_dir = tmp_path / "report"
+    scores = grade(responses, ["a", "b"], str(output_dir))
     assert scores == {1: 0.0, 2: 0.0}
-    assert output_file.read_text().splitlines() == [
-        "Q001: response 1",
-        "Q002: response 2",
-    ]
+    assert (output_dir / "Q001.txt").read_text() == "response 1"
+    assert (output_dir / "Q002.txt").read_text() == "response 2"


### PR DESCRIPTION
## Summary
- store each generated answer in its own file under `report/`
- support `--output-dir` CLI option
- adjust unit tests for new output behaviour
- document new output directory in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472bc9c4bc8321b0bf2b2cb7ff0932